### PR TITLE
[TASK 2] Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Hometask 2
+
+- S3: http://my-store-app-viachaslaut-sls.s3-website.eu-central-1.amazonaws.com/
+- CloudFront distribution: https://d3vpl89h56sp9m.cloudfront.net
+
 # React-shop-cloudfront
 
 This is frontend starter project for nodejs-aws mentoring program. It uses the following technologies:

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: "3"
 provider:
   name: aws
   runtime: nodejs14.x
-  region: eu-west-1
+  region: eu-central-1
   # setup profile for AWS CLI.
   # profile: node-aws
 
@@ -19,7 +19,7 @@ plugins:
 
 custom:
   client:
-    bucketName: my-store-app
+    bucketName: my-store-app-viachaslaut-sls
     distributionFolder: dist
   s3BucketName: ${self:custom.client.bucketName}
 

--- a/src/components/MainLayout/components/Header.tsx
+++ b/src/components/MainLayout/components/Header.tsx
@@ -33,7 +33,7 @@ export default function Header() {
             underline="none"
             to="/"
           >
-            My Store!
+            viachaslaut
           </Link>
         </Typography>
 


### PR DESCRIPTION
- Manual Deployment is implemented. Checked for serving OK via CloudFront (but not via S3 link - 403)
- Manually created S3 bucket and CloudFront distribution deleted according to the requirement 
- Updated `serverless.yml`
- `sls` set up OK
- `npm run cloudfront:build:deploy` works OK
- Updated `README.md` with resulting links to S3 + Cloudfront